### PR TITLE
Improve client scroll state persistence

### DIFF
--- a/src/client/ScrollState.ts
+++ b/src/client/ScrollState.ts
@@ -1,0 +1,120 @@
+const ScrollKey = "_BUNDLER_SCROLL"
+
+type Anchor = {
+  selector: string
+  offset: number
+}
+
+type ScrollState = {
+  scrollY: number
+  anchors: Anchor[]
+}
+
+/**
+ * Persist current scroll state to session storage.
+ * Scroll state is saved relatively to visible elements.
+ */
+export function persist() {
+  const anchors: Anchor[] = []
+  const step = window.innerHeight / 4
+
+  for (let i = 1; i <= 3; i++) {
+    const y = step * i
+    const element = document.elementFromPoint(0, y)
+    if (!element) continue
+    const target = element.id
+      ? element
+      : element.closest("[id]") ?? element
+
+    anchors.push({
+      selector: selectorFromElement(target),
+      offset: target.getBoundingClientRect().top,
+    })
+  }
+
+  const state: ScrollState = {
+    anchors,
+    scrollY: window.scrollY,
+  }
+
+  sessionStorage.setItem(ScrollKey, JSON.stringify(state))
+}
+
+export function restore() {
+  const timeout = 3000
+  const tick = 50
+  const raw = sessionStorage.getItem(ScrollKey)
+  if (!raw) return
+
+  sessionStorage.removeItem(ScrollKey)
+
+  const state: ScrollState = JSON.parse(raw)
+
+  const apply = () => {
+    for (const anchor of state.anchors) {
+      const element = document.querySelector(anchor.selector)
+      if (element) {
+        const rect = element.getBoundingClientRect()
+        const top = window.scrollY + rect.top - anchor.offset
+        window.scrollTo({
+          top,
+        })
+        return
+      }
+    }
+
+    window.scrollTo({
+      top: state.scrollY,
+    })
+  }
+
+  let observer: MutationObserver
+  let stableTimer: ReturnType<typeof setTimeout> | undefined
+  const deadline = setTimeout(() => {
+    observer.disconnect()
+    if (stableTimer) clearTimeout(stableTimer)
+    apply()
+  }, timeout)
+
+  observer = new MutationObserver(() => {
+    if (stableTimer) clearTimeout(stableTimer)
+    stableTimer = setTimeout(() => {
+      observer.disconnect()
+      clearTimeout(deadline)
+      apply()
+    }, tick)
+  })
+
+  observer.observe(document.body, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    characterData: true,
+  })
+
+  stableTimer = setTimeout(() => {
+    observer.disconnect()
+    clearTimeout(deadline)
+    apply()
+  }, tick)
+}
+
+function selectorFromElement(element: Element): string {
+  if (element.id) {
+    return `#${CSS.escape(element.id)}`
+  }
+  const parts: string[] = []
+  let current: Element | null = element
+
+  while (current && current !== document.body) {
+    const parent = current.parentElement
+    if (!parent) break
+    const index = Array
+      .from(parent.children)
+      .indexOf(current) + 1
+    parts.unshift(`${current.tagName.toLowerCase()}:nth-child(${index})`)
+    current = parent
+  }
+
+  return parts.join(" > ")
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,3 +1,9 @@
+/**
+ * This module is intended to be imported in a browser bundle in a development.
+ * It is responsible for live reloading the page when bundle changes.
+ * When NODE_ENV=production, it does nothing.
+ */
+
 /// <reference lib="dom" />
 /// <reference lib="dom.iterable" />
 
@@ -5,124 +11,10 @@ import type {
   BundleEvent,
   BundleManifest,
 } from "../Bundle.ts"
-
-const ScrollKey = "__effect-bundler-scroll__"
-
-type Anchor = {
-  selector: string
-  offset: number
-}
-
-type ScrollState = {
-  scrollY: number
-  anchors: Anchor[]
-}
-
-function selectorFromElement(element: Element): string {
-  if (element.id) {
-    return `#${CSS.escape(element.id)}`
-  }
-  const parts: string[] = []
-  let current: Element | null = element
-
-  while (current && current !== document.body) {
-    const parent = current.parentElement
-    if (!parent) break
-    const index = Array
-      .from(parent.children)
-      .indexOf(current) + 1
-    parts.unshift(`${current.tagName.toLowerCase()}:nth-child(${index})`)
-    current = parent
-  }
-
-  return parts.join(" > ")
-}
-
-function saveScrollState() {
-  const anchors: Anchor[] = []
-  const step = window.innerHeight / 4
-
-  for (let i = 1; i <= 3; i++) {
-    const y = step * i
-    const element = document.elementFromPoint(0, y)
-    if (!element) continue
-    const target = element.id
-      ? element
-      : element.closest("[id]") ?? element
-
-    anchors.push({
-      selector: selectorFromElement(target),
-      offset: target.getBoundingClientRect().top,
-    })
-  }
-
-  const state: ScrollState = {
-    anchors,
-    scrollY: window.scrollY,
-  }
-
-  sessionStorage.setItem(ScrollKey, JSON.stringify(state))
-}
-
-function restoreScrollState() {
-  const raw = sessionStorage.getItem(ScrollKey)
-  if (!raw) return
-
-  sessionStorage.removeItem(ScrollKey)
-
-  const state: ScrollState = JSON.parse(raw)
-
-  const apply = () => {
-    for (const anchor of state.anchors) {
-      const element = document.querySelector(anchor.selector)
-      if (element) {
-        const rect = element.getBoundingClientRect()
-        const top = window.scrollY + rect.top - anchor.offset
-        window.scrollTo({
-          top,
-        })
-        return
-      }
-    }
-
-    window.scrollTo({
-      top: state.scrollY,
-    })
-  }
-
-  let observer: MutationObserver
-  let stableTimer: ReturnType<typeof setTimeout> | undefined
-  const deadline = setTimeout(() => {
-    observer.disconnect()
-    if (stableTimer) clearTimeout(stableTimer)
-    apply()
-  }, 300)
-
-  observer = new MutationObserver(() => {
-    if (stableTimer) clearTimeout(stableTimer)
-    stableTimer = setTimeout(() => {
-      observer.disconnect()
-      clearTimeout(deadline)
-      apply()
-    }, 50)
-  })
-
-  observer.observe(document.body, {
-    subtree: true,
-    childList: true,
-    attributes: true,
-    characterData: true,
-  })
-
-  stableTimer = setTimeout(() => {
-    observer.disconnect()
-    clearTimeout(deadline)
-    apply()
-  }, 50)
-}
+import * as ScrollState from "./ScrollState.ts"
 
 function reload() {
-  saveScrollState()
+  ScrollState.persist()
   window.location.reload()
 }
 
@@ -195,11 +87,7 @@ function reloadAllMetaLinks() {
 
 if (process.env.NODE_ENV !== "production") {
   window.addEventListener("load", () => {
-    restoreScrollState()
+    ScrollState.restore()
     listen()
   })
-}
-
-export {
-  listen,
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -6,7 +6,123 @@ import type {
   BundleManifest,
 } from "../Bundle.ts"
 
+const ScrollKey = "__effect-bundler-scroll__"
+
+type Anchor = {
+  selector: string
+  offset: number
+}
+
+type ScrollState = {
+  scrollY: number
+  anchors: Anchor[]
+}
+
+function selectorFromElement(element: Element): string {
+  if (element.id) {
+    return `#${CSS.escape(element.id)}`
+  }
+  const parts: string[] = []
+  let current: Element | null = element
+
+  while (current && current !== document.body) {
+    const parent = current.parentElement
+    if (!parent) break
+    const index = Array
+      .from(parent.children)
+      .indexOf(current) + 1
+    parts.unshift(`${current.tagName.toLowerCase()}:nth-child(${index})`)
+    current = parent
+  }
+
+  return parts.join(" > ")
+}
+
+function saveScrollState() {
+  const anchors: Anchor[] = []
+  const step = window.innerHeight / 4
+
+  for (let i = 1; i <= 3; i++) {
+    const y = step * i
+    const element = document.elementFromPoint(0, y)
+    if (!element) continue
+    const target = element.id
+      ? element
+      : element.closest("[id]") ?? element
+
+    anchors.push({
+      selector: selectorFromElement(target),
+      offset: target.getBoundingClientRect().top,
+    })
+  }
+
+  const state: ScrollState = {
+    anchors,
+    scrollY: window.scrollY,
+  }
+
+  sessionStorage.setItem(ScrollKey, JSON.stringify(state))
+}
+
+function restoreScrollState() {
+  const raw = sessionStorage.getItem(ScrollKey)
+  if (!raw) return
+
+  sessionStorage.removeItem(ScrollKey)
+
+  const state: ScrollState = JSON.parse(raw)
+
+  const apply = () => {
+    for (const anchor of state.anchors) {
+      const element = document.querySelector(anchor.selector)
+      if (element) {
+        const rect = element.getBoundingClientRect()
+        const top = window.scrollY + rect.top - anchor.offset
+        window.scrollTo({
+          top,
+        })
+        return
+      }
+    }
+
+    window.scrollTo({
+      top: state.scrollY,
+    })
+  }
+
+  let observer: MutationObserver
+  let stableTimer: ReturnType<typeof setTimeout> | undefined
+  const deadline = setTimeout(() => {
+    observer.disconnect()
+    if (stableTimer) clearTimeout(stableTimer)
+    apply()
+  }, 300)
+
+  observer = new MutationObserver(() => {
+    if (stableTimer) clearTimeout(stableTimer)
+    stableTimer = setTimeout(() => {
+      observer.disconnect()
+      clearTimeout(deadline)
+      apply()
+    }, 50)
+  })
+
+  observer.observe(document.body, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    characterData: true,
+  })
+
+  stableTimer = setTimeout(() => {
+    observer.disconnect()
+    clearTimeout(deadline)
+    apply()
+  }, 50)
+}
+
 function reload() {
+  saveScrollState()
   window.location.reload()
 }
 
@@ -79,6 +195,7 @@ function reloadAllMetaLinks() {
 
 if (process.env.NODE_ENV !== "production") {
   window.addEventListener("load", () => {
+    restoreScrollState()
     listen()
   })
 }


### PR DESCRIPTION
## Summary
- keep scroll position across bundle reloads

## Testing
- `bun test` *(fails: Cannot find module '@effect/platform', '@tanstack/react-router', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684a701a1f1c832887a62a0f3ad81bf1