### PR TITLE
Add build error overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "@types/bun": "^1.2.15",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",
-    "effect": ">=3.16.4",
-    "@effect/platform": ">=0.82",
-    "@effect/platform-bun": ">=0.65",
+    "effect": "^3.16.6",
+    "@effect/platform": "^0.84.10",
+    "@effect/platform-bun": "^0.69.15",
     "@tanstack/react-router": "^1.120.18",
     "@tailwindcss/node": ">=4.1.8"
   },

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -70,10 +70,15 @@ export const BundleManifestSchema = S.Struct({
 
 export type BundleManifest = typeof BundleManifestSchema.Type
 
-export type BundleEvent = {
-  type: "Change"
-  path: string
-}
+export type BundleEvent =
+  | {
+    type: "Change"
+    path: string
+  }
+  | {
+    type: "BuildError"
+    error: string
+  }
 
 export type BundleKey = `${string}Bundle`
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -18,7 +18,6 @@ async function loadAllEntrypoints() {
     .keys(manifest.artifacts)
     .filter(v => v.endsWith(".js"))
     .forEach((outFile) => {
-      console.log(outFile)
       const script = document.createElement("script")
       script.src = `/_bundle/${outFile}`
       script.type = "module"
@@ -27,12 +26,53 @@ async function loadAllEntrypoints() {
       }
       document.body.appendChild(script)
     })
+  }
+
+let overlay: HTMLDivElement | null = null
+
+function getOverlay() {
+  if (!overlay) {
+    overlay = document.createElement("div")
+    overlay.style.position = "fixed"
+    overlay.style.top = "0"
+    overlay.style.left = "0"
+    overlay.style.right = "0"
+    overlay.style.maxHeight = "50vh"
+    overlay.style.overflowY = "auto"
+    overlay.style.background = "black"
+    overlay.style.color = "red"
+    overlay.style.fontFamily = "monospace"
+    overlay.style.zIndex = "2147483647"
+    document.body.appendChild(overlay)
+  }
+  return overlay
+}
+
+function appendError(text: string) {
+  const el = getOverlay()
+  const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1
+  const line = document.createElement("pre")
+  line.textContent = text
+  el.appendChild(line)
+  if (atBottom) {
+    el.scrollTop = el.scrollHeight
+  }
+}
+
+function clearOverlay() {
+  overlay?.remove()
+  overlay = null
 }
 
 function handleBundleEvent(event: BundleEvent) {
   if (event.type === "Change") {
     console.debug("Bundle change detected...")
     reload()
+    clearOverlay()
+  }
+
+  if (event.type === "BuildError") {
+    appendError(event.error)
   }
 }
 


### PR DESCRIPTION
## Summary
- send `BuildError` messages from bundler via SSE
- display build errors in a quake-style overlay on the client
- keep previous bundle if rebuild fails
- cleanup unused imports and scripts

## Testing
- `dprint fmt src/bun/BunBundle.ts src/Bundle.ts src/client/index.ts package.json` *(fails: Proxy failed to connect)*
- `bun test` *(fails: Cannot find module '@effect/platform')*

------
https://chatgpt.com/codex/tasks/task_e_684a712e8308832889baf38d3d597c34